### PR TITLE
Improve the documentation landing page

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -38,7 +38,6 @@ Pipelines, of all the components, provides the core functionality of Tekton and 
 ![Pipeline](/docs/concepts/concept-tasks-pipelines.png)
 
 {{% alert title="Note" color="success" %}}
-To get started, read the contents below.
 
 Tekton provides a number of interactive tutorials at [tekton.dev/try](/try)
 for developers to get hands-on experience with the project.

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,6 +1,6 @@
 
 ---
-title: "Tekton Documentation"
+title: "Welcome to Tekton"
 linkTitle: "Documentation"
 weight: 20
 menu:
@@ -8,15 +8,37 @@ menu:
     weight: 20
 ---
 
-Tekton is a cloud native continuous integration and delivery (CI/CD)
+Tekton is an open-source cloud native continuous integration and delivery (CI/CD)
 solution. It allows developers to build, test, and deploy across cloud
 providers and on-premise systems.
 
-### What's next
+The Tekton project consists of the following components:  
 
-To get started, read the contents below.
+- **[Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/main/docs/README.md)** provides basic building blocks (tasks and pipelines) of a CI/CD workflow.
+
+- **[Tekton Triggers](https://github.com/tektoncd/triggers/blob/main/README.md)** allows you to instantiate pipelines based on events.
+
+- **[Tekton CLI](https://github.com/tektoncd/cli/blob/main/README.md)** provides a command-line interface called `tkn`, built on top
+  of the Kubernetes CLI, that allows you to interact with Tekton.
+
+- **[Tekton Dashboard](https://github.com/tektoncd/dashboard/blob/main/README.md)** is a Web-based graphical interface for Tekton
+  Pipelines that displays information about the execution of your pipelines. It is currently a work-in-progress.
+
+- **[Tekton Catalog](https://github.com/tektoncd/catalog/blob/main/README.md)** is a repository of high-quality, community-contributed
+  Tekton building blocks - `Tasks`, `Pipelines`, and so on - that are ready for use in your own pipelines.
+
+- **[Tekton Hub](https://github.com/tektoncd/hub/blob/main/README.md)** is a web based platform for developers to discover, share and contribute tasks and pipelines for Tekton.
+
+- **[Tekton Operator](https://github.com/tektoncd/operator/blob/main/README.md)** is a Kubernetes [Operator](https://operatorhub.io/what-is-an-operator)
+  that allows you to install, update, and remove Tekton projects on your Kubernetes cluster.
+
+- **[Tekton Results](https://github.com/tektoncd/results/blob/main/docs/README.md)** aims to help users logically group CI/CD workload history and separate out long term result storage away from the Pipeline controller.
+
+Pipelines, of all the components, provides the core functionality of Tekton and sets the foundation for the other components.
+![Pipeline](/docs/concepts/concept-tasks-pipelines.png)
 
 {{% alert title="Note" color="success" %}}
+To get started, read the contents below.
 
 Tekton provides a number of interactive tutorials at [tekton.dev/try](/try)
 for developers to get hands-on experience with the project.


### PR DESCRIPTION
* landing page improvement relates to issue #195

- change title from "Tekton Documentation" to "Welcome to Tekton"
- remove "What's next"
- add a list of 8 components with one sentence description about each
- all of the components name has link to its README.md on github main branch
- add a diagram of pipeline