### PR TITLE
Add Tekton home page in Japanese

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,8 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
+hasCJKLanguage = true
+
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
 # Highlighting config
@@ -61,6 +63,18 @@ description = "Cloud Native CI/CD"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
+
+[languages.ja]
+title = "Tekton"
+description = "クラウドネイティブ CI/CD"
+languageName = "日本語"
+contentDir = "content/ja"
+weight = 2
+
+[languages.ja.params]
+time_format_default = "2006/01/02"
+time_format_blog = "2006/01/02"
+language_alternatives = ["en"]
 
 # Everything below this are Site Params
 

--- a/content/ja/_index.html
+++ b/content/ja/_index.html
@@ -1,0 +1,63 @@
++++
+title = "Tekton"
+linkTitle = "Tekton.dev Homepage"
+
++++
+
+{{< blocks/cover title="クラウドネイティブCI/CD" subtitle="" image_anchor="smart" color="orange" height="med">}}
+<div class="mx-auto">
+        <a class="btn btn-lg btn-dark mr-3 mb-4" href="/docs">
+		ドキュメント一覧 <i class="fas fa-arrow-alt-circle-right ml-2"></i>
+	</a>
+	<a class="btn btn-lg btn-light mr-3 mb-4" href="https://github.com/tektoncd">
+		GitHub <i class="fab fa-github ml-2 "></i>
+	</a>
+</div>
+{{< /blocks/cover >}}
+
+{{% blocks/showcase-ja color="link" %}}
+
+{{< blocks/section color="danger" >}}
+{{% blocks/feature icon="fas fa-globe-asia" title="標準化" %}}
+Tekton は CI/CD ツールおよびプロセスを、ベンダー、言語およびデプロイ環境を越えて標準化します。Tektonは、Jenkins、Jenkins X、Skaffold、
+Knative、および他の多くの一般的なCI / CDツールで動作します。
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fas fa-medal" title="ビルトイン・ベストプラクティス" %}}
+Tekton を利用することで、CI/CDシステムの素早い構築と、スケーラブル、サーバーレス、かつ独創的なクラウドネイティブ実行をが可能となります。
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fas fa-feather" title="最高の柔軟性" %}}
+Tektonは基盤となる実装を抽象化することで、ビルド、テストおよびデプロイワークフローをチーム要件に応じて選択できるようにします。
+{{% /blocks/feature %}}
+
+
+{{< /blocks/section >}}
+
+<!--
+{{< blocks/partners color="danger" >}}
+-->
+
+{{< blocks/partners-alternate-ja color="dark" >}}
+
+{{< blocks/section color="white" >}}
+{{% blocks/feature icon="fas fa-code" title="Tektonのインストール" %}}
+<a href="/docs/getting-started/">こちら</a>をご参照ください。
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fab fa-github" title="貢献を歓迎します" url="https://github.com/tektoncd/" %}}
+GitHubでTektonへの貢献をお願いします。
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fas fa-chalkboard" title="Tektonの体験" %}}
+[Tekton Playground](https://katacoda.com/tektoncd/scenarios/playground)で、Tektonの学習、調査および体験ができます。
+{{% /blocks/feature %}}
+
+
+{{< /blocks/section >}}
+
+{{% blocks/manifesto-ja color="dark" %}}

--- a/content/ja/_index.html
+++ b/content/ja/_index.html
@@ -20,7 +20,7 @@ linkTitle = "Tekton.dev Homepage"
 {{< blocks/section color="danger" >}}
 {{% blocks/feature icon="fas fa-globe-asia" title="標準化" %}}
 Tekton は CI/CD ツールおよびプロセスを、ベンダー、言語およびデプロイ環境を越えて標準化します。Tektonは、Jenkins、Jenkins X、Skaffold、
-Knative、および他の多くの一般的なCI / CDツールで動作します。
+Knative、および他の多くの一般的なCI/CDツールで動作します。
 {{% /blocks/feature %}}
 
 

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -1,0 +1,43 @@
+
+
+# UI strings. Buttons and similar.
+
+[ui_pager_prev]
+other = "Previous"
+
+[ui_pager_next]
+other = "Next"
+
+[ui_read_more]
+other = "さらに読む"
+
+[ui_search]
+other = "このサイトを検索…"
+
+# Used in sentences such as "Posted in News"
+[ui_in]
+other = "in"
+
+# Footer text
+[footer_all_rights_reserved]
+other = """
+The Linux Foundation®. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. 
+For a list of trademarks of The Linux Foundation, please see our [Trademark Usage page](https://www.linuxfoundation.org/trademark-usage). 
+Linux is a registered trademark of Linus Torvalds. [Privacy Policy](https://www.linuxfoundation.org/privacy/) and [Terms of Use](https://www.linuxfoundation.org/terms/).
+"""
+
+# Post (blog, articles etc.)
+[post_byline_by]
+other = "By"
+[post_created]
+other = "Created"
+[post_last_mod]
+other = "Last modified"
+[post_edit_this]
+other = "Edit this page"
+[post_create_issue]
+other = "Create documentation issue"
+[post_create_project_issue]
+other = "Create project issue"
+[post_posts_in]
+other = "Posts in"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,7 +18,11 @@
       </main>
       {{ partial "footer.html" . }}
     </div>
+    {{ if eq .Site.Language.Lang "ja" }}
+    {{ partial "privacy-notice-ja.html" }}
+    {{ else }}
     {{ partial "privacy-notice.html" }}
+    {{ end }}
     {{ partialCached "scripts.html" . }}
   </body>
 </html>

--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -1,0 +1,10 @@
+{{/* Link directly to documentation etc., if possible. */}}
+{{ $langPage := cond (gt (len .Translations) 0) . .Site.Home }}
+<a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+	{{ $langPage.Language.LanguageName }}
+</a>
+<div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
+	{{ range $langPage.Translations }}
+	<a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+	{{ end }}
+</div>

--- a/layouts/partials/privacy-notice-ja.html
+++ b/layouts/partials/privacy-notice-ja.html
@@ -1,0 +1,20 @@
+<div id="privacy-notice">
+    <div class="row ml-4 mt-3 mb-3">
+      <div class="col-11">
+        <p class="h5 text-white">このwebサイトはcookieを使用しています。</p>
+        <p class="text-white">
+          サイトトラフィックの理解とよりよいブラウジング体験のためにアナリティクスとcookieを使用します。 プライバシーポリシーについての説明は<a href="https://www.linuxfoundation.org/privacy/" style="color: rgb(236, 109, 95);">こちら</a>です。
+        </p>
+        <button id="privacy-acknowledgement-button" type="button" class="btn btn-lg btn-block" style="background-color: rgb(241, 247, 237); height: 45px;">OK</button>
+      </div>
+    </div>
+</div>
+<script>
+    if (document.cookie.split(';').filter((item) => item.trim().startsWith('privacy-notice-acknowledged=')).length) {
+        $('#privacy-notice').css('display', 'none')
+    }
+    $('#privacy-acknowledgement-button').click(function () {
+        document.cookie = "privacy-notice-acknowledged=true;" + `max-age=${60*60*24*365}`;
+        $('#privacy-notice').css('display', 'none')
+    })
+</script>

--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -25,7 +25,7 @@
 {{ end }}
 <section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height }} js-td-cover td-overlay td-overlay--dark -bg-{{ $col_id }}">
   <div class="container td-overlay__inner">
-    <img id="banner-hero-logo" class="hero-logo" src="images/tekton-horizontal-color.png">
+    <img id="banner-hero-logo" class="hero-logo" src="/images/tekton-horizontal-color.png">
     <div class="row">
       <div class="col-6">
         <div class="text-left">

--- a/layouts/shortcodes/blocks/manifesto-ja.html
+++ b/layouts/shortcodes/blocks/manifesto-ja.html
@@ -14,7 +14,7 @@
 	<div class="container" style="max-width: 100vw;">
 		<div class="row">
 			<div class="col mb-5 text-center">
-				<h3>Tektonは<a href="https://cd.foundation/">継続的デリバリーファウンデーション</a>プロジェクトです。</h3>
+				<h3>Tektonは<a href="https://cd.foundation/">Continuous Delivery Foundation</a>のプロジェクトです。</h3>
 			</div>
 		</div>
   	</div>

--- a/layouts/shortcodes/blocks/manifesto-ja.html
+++ b/layouts/shortcodes/blocks/manifesto-ja.html
@@ -1,0 +1,21 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ $col_id := .Get "color" | default .Ordinal }}
+{{ $height := .Get "height" | default "auto"  }}
+{{/* Height can be one of: auto, min, med, max, full. */}}
+<a id="td-block-{{ .Ordinal }}" class="td-offset-anchor"></a>
+<section class="row td-box td-box--{{ $col_id }} position-relative td-box--gradient td-box--height-{{ $height }}">
+	<div class="container" style="max-width: 600px;">
+		<div class="row">
+			<div class="col mb-5 text-center">
+				<a href="https://cd.foundation/"><img src="/partner-logos/cdf.png" class="img-fluid"></a>
+			</div>
+		</div>
+	</div>
+	<div class="container" style="max-width: 100vw;">
+		<div class="row">
+			<div class="col mb-5 text-center">
+				<h3>Tektonは<a href="https://cd.foundation/">継続的デリバリーファウンデーション</a>プロジェクトです。</h3>
+			</div>
+		</div>
+  	</div>
+</section>

--- a/layouts/shortcodes/blocks/partners-alternate-ja.html
+++ b/layouts/shortcodes/blocks/partners-alternate-ja.html
@@ -13,7 +13,7 @@
 		<div class="row">
 			<div class="col mb-5 text-center">
                 <h3>Tektonは、エコシステムのメンバーが協力してCI/CDを誰にでもより容易にするための共同プロジェクトです。
-                    Tektonプロジェクトに関与している組織及び個人については<a href="https://github.com/tektoncd/friends">こちら</a>
+                    Tektonプロジェクトに関与している個人および組織については<a href="https://github.com/tektoncd/friends">こちら</a>
                     をご覧ください。
 			</div>
 		</div>

--- a/layouts/shortcodes/blocks/partners-alternate-ja.html
+++ b/layouts/shortcodes/blocks/partners-alternate-ja.html
@@ -1,0 +1,21 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ $col_id := .Get "color" | default .Ordinal }}
+{{ $height := .Get "height" | default "auto"  }}
+<section class="row td-box td-box--{{ $col_id }} td-box--gradient td-box--height-{{ $height }}">
+    <div class="container" style="max-width: 600px;">
+		<div class="row">
+			<div class="col mb-5 text-center">
+				<a href="https://github.com/tektoncd/friends"><img src="/partner-logos/tekton-friends.png" class="img-fluid"></a>
+			</div>
+		</div>
+    </div>
+    <div class="container" style="max-width: 100vw;">
+		<div class="row">
+			<div class="col mb-5 text-center">
+                <h3>Tektonは、エコシステムのメンバーが協力してCI/CDを誰にでもより容易にするための共同プロジェクトです。
+                    Tektonプロジェクトに関与している組織及び個人については<a href="https://github.com/tektoncd/friends">こちら</a>
+                    をご覧ください。
+			</div>
+		</div>
+  	</div>
+</section>

--- a/layouts/shortcodes/blocks/showcase-ja.html
+++ b/layouts/shortcodes/blocks/showcase-ja.html
@@ -9,10 +9,10 @@
 			<div class="row p-0">
 				<div class="col-lg-6 mb-5 mb-lg-0">
 					<div class="text-left">
-						<p class="h3 text-light d-inline">Tektonは強力で柔軟性のある </p>
+						<p class="h3 text-light d-inline">Tektonは強力で柔軟性のある</p>
 						<p class="h3 text-dark d-inline">CD/CDシステム構築用のオープンソースフレームワークで、</p>
-						<p class="h3 text-light d-inline">開発者が </p>
-						<p class="h3 text-dark d-inline">ビルド、テストおよびデプロイ </p>
+						<p class="h3 text-light d-inline">開発者が</p>
+						<p class="h3 text-dark d-inline">ビルド、テストおよびデプロイ</p>
 						<p class="h3 text-light d-inline">をクラウドプロバイダーおよびオンプレミスシステム全体で行うことを可能とします。</p>
 						<a class="h3 text-danger d-inline" href="/try">インタラクティブなチュートリアルはこちらから開始可能です。</a>
 					</div>

--- a/layouts/shortcodes/blocks/showcase-ja.html
+++ b/layouts/shortcodes/blocks/showcase-ja.html
@@ -1,0 +1,29 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ $col_id := .Get "color" | default .Ordinal }}
+{{ $height := .Get "height" | default "auto"  }}
+{{/* Height can be one of: auto, min, med, max, full. */}}
+<a id="td-block-{{ .Ordinal }}" class="td-offset-anchor"></a>
+<section class="row td-box td-box--{{ $col_id }} position-relative td-box--gradient td-box--height-{{ $height }}">
+	<div class="container">
+		<div class="col">
+			<div class="row p-0">
+				<div class="col-lg-6 mb-5 mb-lg-0">
+					<div class="text-left">
+						<p class="h3 text-light d-inline">Tektonは強力で柔軟性のある </p>
+						<p class="h3 text-dark d-inline">CD/CDシステム構築用のオープンソースフレームワークで、</p>
+						<p class="h3 text-light d-inline">開発者が </p>
+						<p class="h3 text-dark d-inline">ビルド、テストおよびデプロイ </p>
+						<p class="h3 text-light d-inline">をクラウドプロバイダーおよびオンプレミスシステム全体で行うことを可能とします。</p>
+						<a class="h3 text-danger d-inline" href="/try">インタラクティブなチュートリアルはこちらから開始可能です。</a>
+					</div>
+				</div>
+				<div class="col-lg-6 mb-5 mb-lg-0">
+					{{ $jsAsciinema := resources.Get "js/asciinema-player.js" }}
+					{{ $jsAsciinema := $jsAsciinema | minify | fingerprint }}
+					<script src="{{ $jsAsciinema.RelPermalink }}" integrity="{{ $jsAsciinema.Data.Integrity }}"></script>
+					<asciinema-player src="/asciinema/demo.cast" autoplay="true" rows="18" cols="76" theme="solarized-dark"></asciinema-player>
+				</div>
+			</div>
+		</div>
+  	</div>
+</section>


### PR DESCRIPTION
# Changes

Related to issue [#243](https://github.com/tektoncd/website/issues/243)
- Add Tekton home page texts in Japanese
- Add Japanese translation to
    - ja.toml
    - privacy-notice-ja.html 
    - manifesto-ja.html 
    - partners-alternate-ja.html
- Add Japanese language settings
- Add a language selector for the navigation bar

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
